### PR TITLE
Fixed getExifDateTime so it doesn't infinitely loop until memory is

### DIFF
--- a/Graphics/HsExif.hs
+++ b/Graphics/HsExif.hs
@@ -696,7 +696,7 @@ getExifDateTime = do
 	hour <- getCharValue ' ' >> readDigit 2
 	minute <- getCharValue ':' >> readDigit 2
 	second <- getCharValue ':' >> readDigit 2
-	return $ LocalTime (fromGregorian year month day) (TimeOfDay hour minute second)
+	return $ LocalTime (fromGregorian year month day) (TimeOfDay hour minute $ realToFrac second)
 	where
 		readDigit x = liftM read $ count x getDigit
 


### PR DESCRIPTION
exhausted when trying to obtain the TimeOfDay.

When the test suite attempts to read exif date and time it hangs and uses up all memory and then crashes. For some reason the second field of the TimeOfDay constructor doesn't like the read in value of second. (May have something to do with wanting a Pico type). 

![before](https://cloud.githubusercontent.com/assets/4254359/3444744/ee307a68-0130-11e4-81d0-1234161ddb5e.png)

converting the second to a fractional type allows the test cases to pass and I'm able to successfully extract dates and times in my program. Currently using ghc 7.8.2

![after](https://cloud.githubusercontent.com/assets/4254359/3444755/098b161a-0131-11e4-9613-3c1b2d6c0b6f.png)
