### PR TITLE
Enable compilation under GHC 7.10

### DIFF
--- a/Graphics/ExifTags.hs
+++ b/Graphics/ExifTags.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Graphics.ExifTags where
 

--- a/Graphics/PrettyPrinters.hs
+++ b/Graphics/PrettyPrinters.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables, OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables, OverloadedStrings, FlexibleContexts #-}
 module Graphics.PrettyPrinters where
 
 import Data.List (foldl')

--- a/hsexif.cabal
+++ b/hsexif.cabal
@@ -25,12 +25,12 @@ library
                        binary >=0.7 && <0.8,
                        bytestring >=0.10 && <0.11,
                        containers >= 0.5 && <0.6,
-                       time >= 1.4 && <1.5,
+                       time >= 1.4 && <1.6,
                        iconv >= 0.4 && <0.5,
                        text >= 0.9
   -- hs-source-dirs:      
   default-language:    Haskell2010
-  Ghc-Options:         -Wall
+  Ghc-Options:         -Wall -fno-warn-tabs
 
 test-suite             tests
   type:                 exitcode-stdio-1.0
@@ -43,7 +43,7 @@ test-suite             tests
                        binary >=0.7 && <0.8,
                        bytestring >=0.10 && <0.11,
                        containers >= 0.5 && <0.6,
-                       time >= 1.4 && <1.5,
+                       time >= 1.4 && <1.6,
                        iconv >= 0.4 && <0.5,
                        text >= 0.9
-  Ghc-Options:         -Wall
+  Ghc-Options:         -Wall -fno-warn-tabs


### PR DESCRIPTION
Unfortunately, as-is, hsexif does not compile successfully under GHC version 7.10. For example:

```
Graphics/PrettyPrinters.hs:179:17:
    Non type-variable argument
      in the constraint: Data.String.IsString [a]
    (Use FlexibleContexts to permit this)
    When checking that ‘addComponent’ has the inferred type
      addComponent :: forall a a1.
                      (Eq a1, Num a1, Data.String.IsString [a]) =>
                      [a] -> a1 -> [a]
    In an equation for ‘ppComponentConfiguration’:
        ppComponentConfiguration (ExifUndefined bs)
          = T.pack $ foldl' addComponent [] numbers
          where
              numbers :: [Int] = fromIntegral <$> BS.unpack bs
              addComponent soFar c = soFar ++ formatComponent c
              formatComponent c
                = case c of {
                    0 -> "-"
                    1 -> "Y"
                    2 -> "Cb"
                    3 -> "Cr"
                    4 -> "R"
                    5 -> "G"
                    6 -> "B"
                    _ -> "?" }
```

This patch fixes these compilation issues by including the necessary `FlexibleContexts` extension and expanding the version range of the `time` dependency. Note, these changes are backwards compatible.