### PR TITLE
Ensure that test images are included in tarball.

### DIFF
--- a/hsexif.cabal
+++ b/hsexif.cabal
@@ -14,7 +14,7 @@ maintainer:          etouzery@gmail.com
 -- copyright:
 category:            Graphics
 build-type:          Simple
--- extra-source-files:
+extra-source-files:  tests/*.jpg tests/*.png
 cabal-version:       >=1.10
 
 library


### PR DESCRIPTION
Hi again. Sorry for missing problem the first time but the source tarball for hsexif as generated by `cabal sdist` does not include the test images in the `tests` directory. To ensure that they are included you need to list them under `extra-source-files` in the cabal file. This PR contains an updated cabal file that does just that.

For an example of the problem have a look at the file listing on Hackage (not the lack of files in the tests directory): https://hackage.haskell.org/package/hsexif-0.6.0.2/src/