### PR TITLE
Support more TIFF-based file formats

### DIFF
--- a/Graphics/HsExif.hs
+++ b/Graphics/HsExif.hs
@@ -188,9 +188,10 @@ getExif = do
     firstBytes <- lookAhead $ (,) <$> getWord16be <*> getWord16be
     case firstBytes of
         (0xffd8,_ ) -> getWord16be >> findAndParseExifBlockJPEG
-        (0x4d4d,42) -> findAndParseExifBlockNEF
+        (0x4d4d,42) -> findAndParseExifBlockNEF      -- DNG, Nikon
         (0x4949,42) -> findAndParseExifBlockNEF
-        _           -> fail "Not a JPEG or NEF file"
+        (0x4949,0x2A00) -> findAndParseExifBlockNEF  -- TIFF, Canon CR2, Sony ARW
+        _           -> fail "Not a JPEG, TIFF, or TIFF-based raw file"
 
 findAndParseExifBlockJPEG :: Get (Map ExifTag ExifValue)
 findAndParseExifBlockJPEG = do

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -53,7 +53,7 @@ main = do
 
 testNotAJpeg :: B.ByteString -> Spec
 testNotAJpeg imageContents = it "returns empty list if not a JPEG" $
-    assertEqual' (Left "Not a JPEG or NEF file") (parseExif imageContents)
+    assertEqual' (Left "Not a JPEG, TIFF, or TIFF-based raw file") (parseExif imageContents)
 
 testNoExif :: B.ByteString -> Spec
 testNoExif imageContents = it "returns empty list if no EXIF" $


### PR DESCRIPTION
Many TIFF-based RAW formats work out of the box just by adding their magic numbers. I tested DNG (Leica) and Sony ARW. There is no change needed for DNG since it already matches the first NEF magic numbers.
I did not add test images because of the size and copyright considerations. If this is not acceptable, I could add a Sony ARW test file, but no other formats.