### PR TITLE
Add support for Fuji RAF files

### DIFF
--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -57,7 +57,7 @@ main = do
 
 testNotAJpeg :: B.ByteString -> Spec
 testNotAJpeg imageContents = it "returns empty list if not a JPEG" $
-    assertEqual' (Left "Not a JPEG, TIFF, or TIFF-based raw file") (parseExif imageContents)
+    assertEqual' (Left "Not a JPEG, TIFF, RAF, or TIFF-based raw file") (parseExif imageContents)
 
 testNoExif :: B.ByteString -> Spec
 testNoExif imageContents = it "returns empty list if no EXIF" $


### PR DESCRIPTION
**Adds support for Fuji RAF RAW files by leveraging the existing `findAndParseExifBlockJPEG` function.**

Fuji RAF files contain an embedded JPEG image that also contains the EXIF data ([source](https://libopenraw.freedesktop.org/wiki/Fuji_RAF/)).

I have personally tested on RAF files from:
 - Fuji X-T1 (my own camera)
 - Fuji X-T2 (uncompressed and compressed raws)
 - Fuji X-E2
 - Fuji Finepix S5000

(Raws for various Fuji cameras are available from [here](https://raw.pixls.us/).)

I'm afraid I haven't included any tests, as the RAF files I have are large (> 30mb). Potential solutions to the lack of tests are either:
 - Use a Finepix S5000 RAF file (~6mb)
 - Truncate an existing RAF file to only include the first part of the file (that contains the embedded JPEG image)

I'm not sure either of those is ideal, the S5000 is very old and not a common camera, and I'm not sure what the value is in testing with purposefully broken data.

Shout if you need me to make any changes.