### PR TITLE
allow time 1.9

### DIFF
--- a/hsexif.cabal
+++ b/hsexif.cabal
@@ -27,7 +27,7 @@ library
                        binary >=0.7 && <0.9,
                        bytestring >=0.10 && <0.11,
                        containers >= 0.5 && <0.7,
-                       time >= 1.4 && <1.9,
+                       time >= 1.4 && <1.10,
                        text >= 0.9
   if flag(iconv)
     build-depends:     iconv >= 0.4 && <0.5
@@ -48,7 +48,7 @@ test-suite             tests
                        binary >=0.7 && <0.9,
                        bytestring >=0.10 && <0.11,
                        containers >= 0.5 && <0.7,
-                       time >= 1.4 && <1.9,
+                       time >= 1.4 && <1.10,
                        text >= 0.9
   other-modules:       Graphics.ExifTags,
                        Graphics.Helpers,


### PR DESCRIPTION
Allow `time` `1.9.*`.

This fixes the build with Stackage LTS 15.

I've built it using `nix` / `cabal` and with `stack` & `lts-15.6`.

I haven't checked the code to see if there are any logical issues (see the [`time` `changelog.md`][changelog] for the API changes).

Also, `time` `1.10` is out too, but I haven't been able to test against that.



[changelog]: https://github.com/haskell/time/blob/master/changelog.md