### PR TITLE
Enable build with GHC 9.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cabal.sandbox.config
 *.o
 .stack-work
 stack.yaml
+/dist-newstyle/

--- a/hsexif.cabal
+++ b/hsexif.cabal
@@ -25,9 +25,9 @@ library
   -- other-extensions:
   build-depends:       base >=4.6 && <5,
                        binary >=0.7 && <0.9,
-                       bytestring >=0.10 && <0.11,
+                       bytestring >=0.10 && <0.12,
                        containers >= 0.5 && <0.7,
-                       time >= 1.4 && <1.10,
+                       time >= 1.4 && <1.13,
                        text >= 0.9
   if flag(iconv)
     build-depends:     iconv >= 0.4 && <0.5
@@ -46,9 +46,9 @@ test-suite             tests
                        hspec,
                        HUnit >= 1.2 && <1.7,
                        binary >=0.7 && <0.9,
-                       bytestring >=0.10 && <0.11,
+                       bytestring >=0.10 && <0.12,
                        containers >= 0.5 && <0.7,
-                       time >= 1.4 && <1.10,
+                       time >= 1.4 && <1.13,
                        text >= 0.9
   other-modules:       Graphics.ExifTags,
                        Graphics.Helpers,


### PR DESCRIPTION
Relaxes the bytestring and time dependencies to enable the build with GHC 9.2.2. Tested with Cabal 3.6.2.0 on OpenBSD/amd64 -current.