### PR TITLE
Fixed build-depends for Stackage compatibility

### DIFF
--- a/hsexif.cabal
+++ b/hsexif.cabal
@@ -25,10 +25,10 @@ library
   -- other-extensions:
   build-depends:       base >=4.6 && <5,
                        binary >=0.7 && <0.9,
-                       bytestring >=0.10 && <0.12,
-                       containers >= 0.5 && <0.7,
-                       time >= 1.4 && <1.13,
-                       text >= 0.9
+                       bytestring >=0.10 && <0.13,
+                       containers >= 0.5 && <0.9,
+                       time >=1.14 && <1.20,
+                       text >= 0.9 && <3
   if flag(iconv)
     build-depends:     iconv >= 0.4 && <0.5
     cpp-Options:       -DICONV
@@ -42,14 +42,14 @@ test-suite             tests
   hs-source-dirs: ., tests
   main-is: Tests.hs
   default-language:    Haskell2010
-  build-depends:       base,
-                       hspec,
+  build-depends:       base >=4.6 && <5,
+                       hspec >=2.11.12 && <3,
                        HUnit >= 1.2 && <1.7,
                        binary >=0.7 && <0.9,
-                       bytestring >=0.10 && <0.12,
-                       containers >= 0.5 && <0.7,
-                       time >= 1.4 && <1.13,
-                       text >= 0.9
+                       bytestring >=0.10 && <0.13,
+                       containers >= 0.5 && <0.9,
+                       time >=1.14 && <1.20,
+                       text >= 0.9 && <3
   other-modules:       Graphics.ExifTags,
                        Graphics.Helpers,
                        Graphics.HsExif,


### PR DESCRIPTION
This library was dropped in Stackage snapshot lts-23.28. These build-depends adjustments fix it to build against nightly-2025-09-05.

I maintain a CLI tool that's used this library for many years (photoname). It helps me greatly when it's available in recent Stackage snapshots. These particular build-depends changes are just a suggestion to get this back in Stackage, by all means use your own bounds if these are not right.

And thank you for working on hsexif!