### PR TITLE
Fixed accidentally-moved time lower bound

### DIFF
--- a/hsexif.cabal
+++ b/hsexif.cabal
@@ -27,7 +27,7 @@ library
                        binary >=0.7 && <0.9,
                        bytestring >=0.10 && <0.13,
                        containers >= 0.5 && <0.9,
-                       time >=1.14 && <1.20,
+                       time >=1.4 && <1.20,
                        text >= 0.9 && <3
   if flag(iconv)
     build-depends:     iconv >= 0.4 && <0.5
@@ -48,7 +48,7 @@ test-suite             tests
                        binary >=0.7 && <0.9,
                        bytestring >=0.10 && <0.13,
                        containers >= 0.5 && <0.9,
-                       time >=1.14 && <1.20,
+                       time >=1.4 && <1.20,
                        text >= 0.9 && <3
   other-modules:       Graphics.ExifTags,
                        Graphics.Helpers,


### PR DESCRIPTION
Ah, that wasn't intentional. Here's a fix putting time back to >=1.4 ... if you'd like to merge it.